### PR TITLE
[FEATURE#92516] Fix encodage des caracteres au dela de la norme ISO-8859-1

### DIFF
--- a/src/CsvUtils.php
+++ b/src/CsvUtils.php
@@ -20,7 +20,7 @@ class CsvUtils
             if (is_array($value)) {
                 $tokens = array_merge($tokens, self::getTokenFromArray($value, $sub_prefix));
             } else {
-                $tokens[$sub_prefix] = utf8_decode($value);
+                $tokens[$sub_prefix] = mb_convert_encoding($value, 'Windows-1252', 'UTF-8');
             }
         }
         return $tokens;


### PR DESCRIPTION
Pour résumer, lorsque une entreprise remplie un formulaire depuis fichederenseignement,
qu'elle renseigne par exemple le signe euro dans un des champs du formulaire - propriété 'avantage' dans l'exemple - 
(cela ne touchait pas NOS sigles euro mais bien ceux en provenance d'un input car persisté en base en utf8), 
lors de l'upload d'un template et du passage dans le tokenizer des mergefields avec cette donné contenant un sigle euro en utf8,
la fonction utf8_decode ne suffisait pas a traduire le caractere appartenant a la norme windows-1252.

Avant: 

![screen shot 2018-05-30 at 16 26 51](https://user-images.githubusercontent.com/16307418/40728924-7d71066e-642b-11e8-810c-907a94a45124.png)

![screen shot 2018-05-30 at 16 26 19](https://user-images.githubusercontent.com/16307418/40728960-94fc3f4c-642b-11e8-832c-14e4e15da869.png)

![screen shot 2018-05-30 at 16 25 41](https://user-images.githubusercontent.com/16307418/40728974-9d73db94-642b-11e8-8b31-5987c74117dd.png)

Apres : (le var_dump/print_r ne suffit pas a débug...)

![screen shot 2018-05-30 at 16 27 07](https://user-images.githubusercontent.com/16307418/40729033-bf1170c2-642b-11e8-98ae-7ada8c1cc0a0.png)

![screen shot 2018-05-30 at 16 32 16](https://user-images.githubusercontent.com/16307418/40729047-cab386ea-642b-11e8-929b-8e5cdcdc1cbd.png)

![screen shot 2018-05-30 at 16 33 01](https://user-images.githubusercontent.com/16307418/40729052-cee56c10-642b-11e8-8cc6-a2a2fd9117a1.png)

